### PR TITLE
Add stringify

### DIFF
--- a/include/mapbox/geojson.hpp
+++ b/include/mapbox/geojson.hpp
@@ -7,6 +7,8 @@ namespace mapbox {
 namespace geojson {
 
 using value               = mapbox::geometry::value;
+using null_value_t        = mapbox::geometry::null_value_t;
+using identifier          = mapbox::geometry::identifier;
 using point               = mapbox::geometry::point<double>;
 using multi_point         = mapbox::geometry::multi_point<double>;
 using line_string         = mapbox::geometry::line_string<double>;
@@ -27,6 +29,14 @@ T parse(const std::string &);
 // Parse any GeoJSON type.
 using geojson = mapbox::util::variant<geometry, feature, feature_collection>;
 geojson parse(const std::string &);
+
+// Stringify inputs of known types. Instantiations are provided for geometry, feature, and
+// feature_collection.
+template <class T>
+std::string stringify(const T &);
+
+// Stringify any GeoJSON type.
+std::string stringify(const geojson &);
 
 } // namespace geojson
 } // namespace mapbox

--- a/include/mapbox/geojson/rapidjson.hpp
+++ b/include/mapbox/geojson/rapidjson.hpp
@@ -8,16 +8,25 @@ namespace geojson {
 
 // Use the CrtAllocator, because the MemoryPoolAllocator is broken on ARM
 // https://github.com/miloyip/rapidjson/issues/200, 301, 388
-using rapidjson_document = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator>;
-using rapidjson_value = rapidjson::GenericValue<rapidjson::UTF8<>, rapidjson::CrtAllocator>;
+using rapidjson_allocator = rapidjson::CrtAllocator;
+using rapidjson_document = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson_allocator>;
+using rapidjson_value = rapidjson::GenericValue<rapidjson::UTF8<>, rapidjson_allocator>;
 
 // Convert inputs of known types. Instantiations are provided for geometry, feature, and
 // feature_collection.
 template <typename T>
-T convert(const rapidjson_value &json);
+T convert(const rapidjson_value &);
 
 // Convert any GeoJSON type.
-geojson convert(const rapidjson_value &json);
+geojson convert(const rapidjson_value &);
+
+// Convert back to rapidjson value. Instantiations are provided for geometry, feature, and
+// feature_collection.
+template <typename T>
+rapidjson_value convert(const T &, rapidjson_allocator&);
+
+// Convert any GeoJSON type.
+rapidjson_value convert(const geojson &, rapidjson_allocator&);
 
 } // namespace geojson
 } // namespace mapbox

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,6 +2,9 @@
 #include <mapbox/geojson/rapidjson.hpp>
 #include <mapbox/geometry.hpp>
 
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
+
 #include <cassert>
 #include <fstream>
 #include <sstream>
@@ -22,6 +25,19 @@ geojson readGeoJSON(const std::string &path, bool use_convert) {
     }
 }
 
+template <class T>
+std::string writeGeoJSON(const T& t, bool use_convert) {
+    if (use_convert) {
+        rapidjson_allocator allocator;
+        rapidjson::StringBuffer buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+        convert(t, allocator).Accept(writer);
+        return buffer.GetString();
+    } else {
+        return stringify(t);
+    }
+}
+
 static void testPoint(bool use_convert) {
     const auto &data = readGeoJSON("test/fixtures/point.json", use_convert);
     assert(data.is<geometry>());
@@ -33,7 +49,7 @@ static void testPoint(bool use_convert) {
     assert(p.x == 30.5);
     assert(p.y == 50.5);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testMultiPoint(bool use_convert) {
@@ -46,7 +62,7 @@ static void testMultiPoint(bool use_convert) {
     const auto &points = geom.get<multi_point>();
     assert(points.size() == 2);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testLineString(bool use_convert) {
@@ -59,7 +75,7 @@ static void testLineString(bool use_convert) {
     const auto &points = geom.get<line_string>();
     assert(points.size() == 2);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testMultiLineString(bool use_convert) {
@@ -73,7 +89,7 @@ static void testMultiLineString(bool use_convert) {
     assert(lines.size() == 1);
     assert(lines[0].size() == 2);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testPolygon(bool use_convert) {
@@ -88,7 +104,7 @@ static void testPolygon(bool use_convert) {
     assert(rings[0].size() == 5);
     assert(rings[0][0] == rings[0][4]);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testMultiPolygon(bool use_convert) {
@@ -104,7 +120,7 @@ static void testMultiPolygon(bool use_convert) {
     assert(polygons[0][0].size() == 5);
     assert(polygons[0][0][0] == polygons[0][0][4]);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testGeometryCollection(bool use_convert) {
@@ -118,7 +134,7 @@ static void testGeometryCollection(bool use_convert) {
     assert(collection[0].is<point>());
     assert(collection[1].is<line_string>());
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testFeature(bool use_convert) {
@@ -154,7 +170,7 @@ static void testFeature(bool use_convert) {
     assert(nested.get<values>().at(1).get<prop_map>().at("foo").is<std::string>());
     assert(nested.get<values>().at(1).get<prop_map>().at("foo").get<std::string>() == "bar");
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testFeatureNullProperties(bool use_convert) {
@@ -165,7 +181,7 @@ static void testFeatureNullProperties(bool use_convert) {
     assert(f.geometry.is<point>());
     assert(f.properties.size() == 0);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 static void testFeatureCollection(bool use_convert) {
@@ -175,7 +191,7 @@ static void testFeatureCollection(bool use_convert) {
     const auto &features = data.get<feature_collection>();
     assert(features.size() == 2);
 
-    assert(parse(stringify(data)) == data);
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
 void testAll(bool use_convert) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <fstream>
 #include <sstream>
+#include <iostream>
 
 using namespace mapbox::geojson;
 
@@ -31,6 +32,8 @@ static void testPoint(bool use_convert) {
     const auto &p = geom.get<point>();
     assert(p.x == 30.5);
     assert(p.y == 50.5);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testMultiPoint(bool use_convert) {
@@ -42,6 +45,8 @@ static void testMultiPoint(bool use_convert) {
 
     const auto &points = geom.get<multi_point>();
     assert(points.size() == 2);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testLineString(bool use_convert) {
@@ -53,6 +58,8 @@ static void testLineString(bool use_convert) {
 
     const auto &points = geom.get<line_string>();
     assert(points.size() == 2);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testMultiLineString(bool use_convert) {
@@ -65,6 +72,8 @@ static void testMultiLineString(bool use_convert) {
     const auto &lines = geom.get<multi_line_string>();
     assert(lines.size() == 1);
     assert(lines[0].size() == 2);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testPolygon(bool use_convert) {
@@ -78,6 +87,8 @@ static void testPolygon(bool use_convert) {
     assert(rings.size() == 1);
     assert(rings[0].size() == 5);
     assert(rings[0][0] == rings[0][4]);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testMultiPolygon(bool use_convert) {
@@ -92,6 +103,8 @@ static void testMultiPolygon(bool use_convert) {
     assert(polygons[0].size() == 1);
     assert(polygons[0][0].size() == 5);
     assert(polygons[0][0][0] == polygons[0][0][4]);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testGeometryCollection(bool use_convert) {
@@ -104,6 +117,8 @@ static void testGeometryCollection(bool use_convert) {
     const auto &collection = geom.get<geometry_collection>();
     assert(collection[0].is<point>());
     assert(collection[1].is<line_string>());
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testFeature(bool use_convert) {
@@ -138,6 +153,8 @@ static void testFeature(bool use_convert) {
     assert(nested.get<values>().at(1).is<mapbox::util::recursive_wrapper<prop_map>>());
     assert(nested.get<values>().at(1).get<prop_map>().at("foo").is<std::string>());
     assert(nested.get<values>().at(1).get<prop_map>().at("foo").get<std::string>() == "bar");
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testFeatureNullProperties(bool use_convert) {
@@ -147,6 +164,8 @@ static void testFeatureNullProperties(bool use_convert) {
     const auto &f = data.get<feature>();
     assert(f.geometry.is<point>());
     assert(f.properties.size() == 0);
+
+    assert(parse(stringify(data)) == data);
 }
 
 static void testFeatureCollection(bool use_convert) {
@@ -155,6 +174,8 @@ static void testFeatureCollection(bool use_convert) {
 
     const auto &features = data.get<feature_collection>();
     assert(features.size() == 2);
+
+    assert(parse(stringify(data)) == data);
 }
 
 void testAll(bool use_convert) {


### PR DESCRIPTION
This uses the RapidJSON SAX interface for writing. But I think we are going to need a version that serializes to RapidJSON DOM as well -- the "stringify" equivalent of https://github.com/mapbox/geojson-cpp/blob/c72c477babc3c33cace044cc46fd203c10b0f5a7/include/mapbox/geojson/rapidjson.hpp#L16-L20.

cc @mourner 