### PR TITLE
Set visibility hidden by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ mason_packages/headers/geometry:
 build:
 	mkdir -p build
 
+CFLAGS += -fvisibility=hidden
+
 build/geojson.o: src/mapbox/geojson.cpp include/mapbox/geojson.hpp include/mapbox/geojson_impl.hpp build mason_packages/headers/geometry Makefile
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPS) $(RAPIDJSON_DEP) -c $< -o $@
 


### PR DESCRIPTION
This avoids these warning messages when building Mapbox GL native on macOS:
```
ld: warning: direct access in function 'mbgl::style::Filter& mapbox::util::variant<mbgl::style::Filter, mbgl::style::conversion::Error>::get<mbgl::style::Filter, (void*)0>()' from file 'libmbgl-core.a(qmapboxgl.cpp.o)' to global weak symbol 'typeinfo for mapbox::util::bad_variant_access' from file '../../../mason_packages/osx-x86_64/geojson/0.3.0/lib/libgeojson.a(geojson.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

/cc @kkaefer @tmpsantos 