### PR TITLE
Fix shadowing warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -I include -std=c++14 -Wall -Wextra -Werror -O3 -fPIC
+CXXFLAGS += -I include -std=c++14 -Wall -Wextra -Wshadow -Werror -O3 -fPIC
 
 MASON ?= .mason/mason
 VARIANT = variant 1.1.0


### PR DESCRIPTION
We have a couple of instances where we use names that are identical to types and will get shadowing warnings.