### PR TITLE
Allow missing properties object on Feature

### DIFF
--- a/include/mapbox/geojson_impl.hpp
+++ b/include/mapbox/geojson_impl.hpp
@@ -173,13 +173,11 @@ feature convert<feature>(const rapidjson_value &json) {
     }
 
     auto const &prop_itr = json.FindMember("properties");
-
-    if (prop_itr == json_end)
-        throw error("Feature must have a properties property");
-
-    const auto &json_props = prop_itr->value;
-    if (!json_props.IsNull()) {
-        result.properties = convert<prop_map>(json_props);
+    if (prop_itr != json_end) {
+        const auto &json_props = prop_itr->value;
+        if (!json_props.IsNull()) {
+            result.properties = convert<prop_map>(json_props);
+        }
     }
 
     return result;

--- a/test/fixtures/feature-missing-properties.json
+++ b/test/fixtures/feature-missing-properties.json
@@ -1,0 +1,7 @@
+{
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [30.5, 50.5]
+    }
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -184,6 +184,17 @@ static void testFeatureNullProperties(bool use_convert) {
     assert(parse(writeGeoJSON(data, use_convert)) == data);
 }
 
+static void testFeatureMissingProperties(bool use_convert) {
+    const auto &data = readGeoJSON("test/fixtures/feature-missing-properties.json", use_convert);
+    assert(data.is<feature>());
+
+    const auto &f = data.get<feature>();
+    assert(f.geometry.is<point>());
+    assert(f.properties.size() == 0);
+
+    assert(parse(writeGeoJSON(data, use_convert)) == data);
+}
+
 static void testFeatureCollection(bool use_convert) {
     const auto &data = readGeoJSON("test/fixtures/feature-collection.json", use_convert);
     assert(data.is<feature_collection>());
@@ -225,6 +236,7 @@ void testAll(bool use_convert) {
     testGeometryCollection(use_convert);
     testFeature(use_convert);
     testFeatureNullProperties(use_convert);
+    testFeatureMissingProperties(use_convert);
     testFeatureCollection(use_convert);
     testFeatureID(use_convert);
 }


### PR DESCRIPTION
The [GeoJSON spec](https://tools.ietf.org/html/rfc7946#section-3.2) says 

> A Feature object has a member with the name "properties".

But it doesn't specifically mention whether they are required or not. I can't see any harm in treating a missing `properties` key like a `null` value (== no properties).