### PR TITLE
Fix template instantiations and visibility

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ NamespaceIndentation: None
 PointerBindsToType: false
 SpacesInParentheses: false
 BreakBeforeBraces: Attach
-ColumnLimit: 100
+ColumnLimit: 120
 Cpp11BracedListStyle: false
 SpacesBeforeTrailingComments: 1
 AlignConsecutiveAssignments: true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RAPIDJSON = rapidjson 1.1.0
 DEPS = `$(MASON) cflags $(VARIANT)` `$(MASON) cflags $(GEOMETRY)`
 RAPIDJSON_DEP = `$(MASON) cflags $(RAPIDJSON)`
 
-default: build/libgeojson.a
+default: build/libgeojson.so
 
 mason_packages/headers/geometry:
 	$(MASON) install $(VARIANT)
@@ -23,18 +23,18 @@ CFLAGS += -fvisibility=hidden
 build/geojson.o: src/mapbox/geojson.cpp include/mapbox/geojson.hpp include/mapbox/geojson_impl.hpp include/mapbox/geojson_value_impl.hpp build mason_packages/headers/geometry Makefile
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPS) $(RAPIDJSON_DEP) -c $< -o $@
 
-build/libgeojson.a: build/geojson.o
-	$(AR) -rcs $@ $<
+build/libgeojson.so: build/geojson.o
+	$(CXX) -shared $< -o $@
 
-build/test: test/test.cpp test/fixtures/* build/libgeojson.a
+build/test: test/test.cpp test/fixtures/* build/libgeojson.so
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPS) $(RAPIDJSON_DEP) $< -Lbuild -lgeojson -o $@
 
-build/test_value: test/test_value.cpp test/fixtures/* build/libgeojson.a
+build/test_value: test/test_value.cpp test/fixtures/* build/libgeojson.so
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPS) $(RAPIDJSON_DEP) $< -Lbuild -lgeojson -o $@
 
 test: build/test build/test_value
-	./build/test
-	./build/test_value
+	LD_LIBRARY_PATH=`pwd`/build ./build/test
+	LD_LIBRARY_PATH=`pwd`/build ./build/test_value
 
 format:
 	clang-format include/mapbox/*.hpp src/mapbox/geojson.cpp test/*.cpp -i

--- a/include/mapbox/geojson.hpp
+++ b/include/mapbox/geojson.hpp
@@ -24,16 +24,17 @@ using identifier          = mapbox::feature::identifier;
 using feature             = mapbox::feature::feature<double>;
 using feature_collection  = mapbox::feature::feature_collection<double>;
 
-// Parse inputs of known types. Instantiations are provided for geometry, feature, and
+using geojson             = mapbox::util::variant<geometry, feature, feature_collection>;
+
+// Parse inputs of known types. Instantiations are provided for geojson, geometry, feature, and
 // feature_collection.
 template <class T>
 T parse(const std::string &);
 
 // Parse any GeoJSON type.
-using geojson = mapbox::util::variant<geometry, feature, feature_collection>;
 geojson parse(const std::string &);
 
-// Stringify inputs of known types. Instantiations are provided for geometry, feature, and
+// Stringify inputs of known types. Instantiations are provided for geojson, geometry, feature, and
 // feature_collection.
 template <class T>
 std::string stringify(const T &);

--- a/include/mapbox/geojson/rapidjson.hpp
+++ b/include/mapbox/geojson/rapidjson.hpp
@@ -12,7 +12,7 @@ using rapidjson_allocator = rapidjson::CrtAllocator;
 using rapidjson_document = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson_allocator>;
 using rapidjson_value = rapidjson::GenericValue<rapidjson::UTF8<>, rapidjson_allocator>;
 
-// Convert inputs of known types. Instantiations are provided for geometry, feature, and
+// Convert inputs of known types. Instantiations are provided for geojson, geometry, feature, and
 // feature_collection.
 template <typename T>
 T convert(const rapidjson_value &);
@@ -20,7 +20,7 @@ T convert(const rapidjson_value &);
 // Convert any GeoJSON type.
 geojson convert(const rapidjson_value &);
 
-// Convert back to rapidjson value. Instantiations are provided for geometry, feature, and
+// Convert back to rapidjson value. Instantiations are provided for geojson, geometry, feature, and
 // feature_collection.
 template <typename T>
 rapidjson_value convert(const T &, rapidjson_allocator&);

--- a/include/mapbox/geojson/value.hpp
+++ b/include/mapbox/geojson/value.hpp
@@ -5,8 +5,18 @@
 namespace mapbox {
 namespace geojson {
 
+// Convert Value to known types. Instantiations are provided for geojson, geometry, feature, and
+// feature_collection.
+template <class T>
+T convert(const mapbox::geojson::value &);
+
 // Converts Value to GeoJSON type.
 geojson convert(const mapbox::geojson::value&);
+
+// Convert inputs of known types to Value. Instantiations are provided for geojson, geometry, feature, and
+// feature_collection.
+template <class T>
+mapbox::geojson::value convert(const T &);
 
 // Converts GeoJSON type to Value.
 mapbox::geojson::value convert(const geojson&);

--- a/include/mapbox/geojson_value_impl.hpp
+++ b/include/mapbox/geojson_value_impl.hpp
@@ -3,6 +3,10 @@
 #include <mapbox/geojson.hpp>
 #include <mapbox/geojson/value.hpp>
 
+#ifndef MAPBOX_GEOJSON_VALUE_VISIBILITY
+#define MAPBOX_GEOJSON_VALUE_VISIBILITY MAPBOX_GEOJSON_VISIBILITY
+#endif
+
 namespace mapbox {
 namespace geojson {
 
@@ -56,7 +60,7 @@ Container convert(const value &val) {
 }
 
 template <>
-geometry convert<geometry>(const value &val) {
+MAPBOX_GEOJSON_VALUE_VISIBILITY geometry convert<geometry>(const value &val) {
     auto *valueObject = val.getObject();
     if (!valueObject) {
         throw error("GeoJSON must be an object");
@@ -115,7 +119,7 @@ geometry convert<geometry>(const value &val) {
 }
 
 template <>
-feature convert<feature>(const value &val) {
+MAPBOX_GEOJSON_VALUE_VISIBILITY feature convert<feature>(const value &val) {
     auto *valueObject = val.getObject();
     if (!valueObject) {
         throw error("GeoJSON must be an object");
@@ -166,7 +170,7 @@ feature convert<feature>(const value &val) {
 }
 
 template <>
-geojson convert<geojson>(const value &val) {
+MAPBOX_GEOJSON_VALUE_VISIBILITY geojson convert<geojson>(const value &val) {
     auto *valueObject = val.getObject();
     if (!valueObject) {
         throw error("GeoJSON must be an object");
@@ -209,7 +213,9 @@ geojson convert<geojson>(const value &val) {
     return geojson{ convert<geometry>(val) };
 }
 
-geojson convert(const value &val) {
+template MAPBOX_GEOJSON_VALUE_VISIBILITY feature_collection convert<feature_collection>(const value &);
+
+MAPBOX_GEOJSON_VALUE_VISIBILITY geojson convert(const value &val) {
     return val.match(
         [](const null_value_t &) -> geojson { return geometry{}; },
         [](const std::string &jsonString) {
@@ -235,7 +241,8 @@ value convert(const Cont &points) {
     return result;
 }
 
-value convert(const geometry &geom) {
+template <>
+MAPBOX_GEOJSON_VALUE_VISIBILITY value convert(const geometry &geom) {
     return geom.match(
         [](const empty &) { return value{}; },
         [](const point &p) {
@@ -269,7 +276,8 @@ value convert(const geometry &geom) {
         });
 }
 
-value convert(const feature &f) {
+template <>
+MAPBOX_GEOJSON_VALUE_VISIBILITY value convert(const feature &f) {
     value::object_type result{
         { "type", "Feature" },
         { "geometry", convert(f.geometry) },
@@ -287,7 +295,8 @@ value convert(const feature &f) {
     return result;
 }
 
-value convert(const feature_collection &collection) {
+template <>
+MAPBOX_GEOJSON_VALUE_VISIBILITY value convert(const feature_collection &collection) {
     value::object_type result{ { "type", "FeatureCollection" } };
     value::array_type features;
     features.reserve(collection.size());
@@ -298,7 +307,12 @@ value convert(const feature_collection &collection) {
     return result;
 }
 
-value convert(const geojson &json) {
+template <>
+MAPBOX_GEOJSON_VALUE_VISIBILITY value convert(const geojson& json) {
+    return convert(json);
+}
+
+MAPBOX_GEOJSON_VALUE_VISIBILITY value convert(const geojson &json) {
     return json.match([](const geometry &g) { return convert(g); },
                       [](const feature &f) { return convert(f); },
                       [](const feature_collection &c) { return convert(c); });

--- a/src/mapbox/geojson.cpp
+++ b/src/mapbox/geojson.cpp
@@ -1,2 +1,4 @@
+#define MAPBOX_GEOJSON_VISIBILITY __attribute__((visibility ("default")))
+
 #include <mapbox/geojson_impl.hpp>
 #include <mapbox/geojson_value_impl.hpp>


### PR DESCRIPTION
The *_impl.hpp files has defects when instantiating the promised symbols. Instead of this template _specialization declaration_:

```cpp
template <> geometry parse<geometry>(const std::string &);
```

it should’ve been a template _instantiation_:

```cpp
template geometry parse<geometry>(const std::string &);
```

Additionally, it introduces a few macros that allow controlling symbol visibility:

Adds `MAPBOX_GEOJSON_VISIBILITY`, `MAPBOX_GEOJSON_RAPIDJSON_VISIBILITY`, and `MAPBOX_GEOJSON_VALUE_VISIBILITY`. If defined (e.g. to `__attribute__((visibility ("default")))`) they will allow you to set the visiblity of the symbols for the *_impl.hpp files. `MAPBOX_GEOJSON_VISIBILITY` propagates to the other two, so if you just want parse/stringify, but e.g. not RapidJSON explicitly define the other two to be empty.

I used `nm` to check that the shared library includes the correct public symbols:

```
geojson parse(std::const string&)
geojson parse<geojson>(std::const string&)
feature_collection parse<feature_collection>(std::const string&)
feature parse<feature>(std::const string&)
geometry parse<geometry>(std::const string&)

std::string stringify(const geojson&)
std::string stringify<geojson>(const geojson&)
std::string stringify<feature_collection>(const feature_collection&)
std::string stringify<feature>(const feature&)
std::string stringify<geometry>(const geometry&)

geojson convert(const rapidjson_value&)
geojson convert<geojson>(const rapidjson_value&)
feature_collection convert<feature_collection>(const rapidjson_value&)
feature convert<feature>(const rapidjson_value&)
geometry convert<geometry>(const rapidjson_value&)

rapidjson_value convert(const geojson&, rapidjson_allocator&)
rapidjson_value convert<geojson>(const geojson&, rapidjson_allocator&)
rapidjson_value convert<feature_collection>(const feature_collection&, rapidjson_allocator&)
rapidjson_value convert<feature>(const feature&, rapidjson_allocator&)
rapidjson_value convert<geometry>(const geometry&, rapidjson_allocator&)

geojson convert(const value&)
geojson convert<geojson>(const value&)
feature_collection convert<feature_collection>(const value&)
feature convert<feature>(const value&)
geometry convert<geometry>(const value&)

value convert(const geojson&)
value convert<geojson>(const geojson&)
value convert<feature_collection>(const feature_collection&)
value convert<feature>(const feature&)
value convert<geometry>(const geometry&)
```