### PR TITLE
Add validation to check matching first and last points of polygons

### DIFF
--- a/test/fixtures/invalid-polygon-mismatch.json
+++ b/test/fixtures/invalid-polygon-mismatch.json
@@ -1,0 +1,10 @@
+{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [[100, 0], [101, 0], [101, 1], [100, 1], [100, 10]]
+        ]
+    }
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -264,6 +264,13 @@ static void testParseErrorHandling() {
     }
 
     try {
+        readGeoJSON("test/fixtures/invalid-polygon-mismatch.json", false);
+        assert(false && "Should have thrown an error");
+    } catch (const std::runtime_error& err) {
+        assert(std::string(err.what()).find("first and last") != std::string::npos);
+    }
+
+    try {
         readGeoJSON("test/fixtures/invalid-multi-polygon.json", false);
         assert(false && "Should have thrown an error");
     } catch (const std::runtime_error& err) {


### PR DESCRIPTION
The GeoJSON specification states in section [3.1.6](https://www.rfc-editor.org/rfc/rfc7946#section-3.1.6) about the linear rings of polygons:

`The first and last positions are equivalent, and they MUST contain identical values; their representation SHOULD also be identical.`

https://www.rfc-editor.org/rfc/rfc7946#section-3.1.6

This PR add a validation rule for this requirement.